### PR TITLE
fix some edge cases in lexer

### DIFF
--- a/lib/utils/lexer.dart
+++ b/lib/utils/lexer.dart
@@ -56,7 +56,7 @@ Token getNextToken(Lexer lexer) {
       }
 
       // +=
-      if (lexer.currentChar == '=') {
+      else if (lexer.currentChar == '=') {
         type = TokenType.TOKEN_PLUS_EQUAL;
         value += lexer.currentChar;
         advance(lexer);
@@ -81,7 +81,7 @@ Token getNextToken(Lexer lexer) {
       }
 
       // -=
-      if (lexer.currentChar == '=') {
+      else if (lexer.currentChar == '=') {
         type = TokenType.TOKEN_SUB_EQUAL;
         value += lexer.currentChar;
 
@@ -105,7 +105,7 @@ Token getNextToken(Lexer lexer) {
       }
 
       // *=
-      if (lexer.currentChar == '=') {
+      else if (lexer.currentChar == '=') {
         type = TokenType.TOKEN_MUL_EQUAL;
         value += lexer.currentChar;
         advance(lexer);
@@ -252,7 +252,13 @@ void advance(Lexer lexer) {
     lexer.currentChar = lexer.contents[lexer.currentIndex];
   } else if (lexer.currentIndex == lexer.contents.length - 1) {
     lexer.currentIndex++;
+    lexer.currentChar = null;
   }
+}
+
+/// Checks whether the input has been fully consumed
+bool isAtEnd(Lexer lexer) {
+  return lexer.currentIndex == lexer.contents.length;
 }
 
 /// Advances while returning a Token
@@ -288,7 +294,7 @@ void skipWhitespace(Lexer lexer) {
 
 /// Skip comments since they are only notes for the developers
 void skipInlineComment(Lexer lexer) {
-  while (lexer.currentChar != '\n' && lexer.currentChar != '\n') {
+  while (lexer.currentChar != '\n' && lexer.currentChar != '\n' && !isAtEnd(lexer)) {
     advance(lexer);
   }
 }

--- a/test/lexer_test.dart
+++ b/test/lexer_test.dart
@@ -10,6 +10,45 @@ void main() {
     test.expect(getNextToken(lexer).type, test.equals(TokenType.TOKEN_EOF));
   });
 
+  test.test('Lexer handles equal char after double char tokens correctly', () {
+    void testInput(String input, List<TokenType> expectations) {
+      // new line so that end of input errors don't get mixed up in this test
+      final lexer = initLexer(input + '\n');
+      for (final token in expectations) {
+        test.expect(getNextToken(lexer).type, test.equals(token));
+      }
+      test.expect(getNextToken(lexer).type, test.equals(TokenType.TOKEN_EOF));
+    }
+    
+    testInput('++=', [TokenType.TOKEN_PLUS_PLUS, TokenType.TOKEN_EQUAL]);
+    testInput('--=', [TokenType.TOKEN_SUB_SUB, TokenType.TOKEN_EQUAL]);
+    testInput('**=', [TokenType.TOKEN_MUL_MUL, TokenType.TOKEN_EQUAL]);
+  });
+
+  test.group('Lexer handles end of input correctly for', () {
+    test.test('comment', () {
+      Lexer lexer = initLexer("// this is a comment that doesn't end with a new line");
+      test.expect(getNextToken(lexer).type, test.equals(TokenType.TOKEN_EOF));
+    });
+
+    test.test('single character tokens', () {
+      void testInput(String input, TokenType type, TokenType notType) {
+        Lexer lexer = initLexer(input);
+        final token = getNextToken(lexer);
+        test.expect(token.type, test.equals(type));
+        test.expect(token, test.isNot(test.equals(notType)));
+        test.expect(getNextToken(lexer).type, test.equals(TokenType.TOKEN_EOF));
+      }
+
+      testInput('+', TokenType.TOKEN_PLUS, TokenType.TOKEN_PLUS_PLUS);
+      testInput('-', TokenType.TOKEN_SUB, TokenType.TOKEN_SUB_SUB);
+      testInput('*', TokenType.TOKEN_MUL, TokenType.TOKEN_MUL_MUL);
+      testInput('=', TokenType.TOKEN_EQUAL, TokenType.TOKEN_EQUALITY);
+      // since comment tokens are ignored we check that the returned token isn't EOF
+      testInput('/', TokenType.TOKEN_DIV, TokenType.TOKEN_EOF);
+    });
+  });
+
   test.test('Lexer gets tokens correctly', () {
     Lexer lexer =
         initLexer(File('./test/TestPrograms/test_lexer.birb').readAsStringSync());


### PR DESCRIPTION
- fix lexer scanned for a third equal char after matching some of the two char tokens.
- fix lexer hanged on last char even after reaching end of input causing false double char tokens.
- fix lexer entered infinite loop if last line of input is a comment.