### PR TITLE
Better testing support

### DIFF
--- a/examples/attribute_access.birb
+++ b/examples/attribute_access.birb
@@ -1,7 +1,7 @@
 int length = "foo".length;
 
 assert(length == 3);
-screm(length);
+screm(length); // output 3
 
 assert(length.isEven == false);
-screm(length.isEven);
+screm(length.isEven); // output false

--- a/examples/bitwise.birb
+++ b/examples/bitwise.birb
@@ -2,19 +2,19 @@ int a = 101;
 int b = 202;
 
 assert((a & b) == 64);
-screm(a & b);
+screm(a & b); // output 64
 
 assert((a | b) == 239);
-screm(a | b);
+screm(a | b); // output 239
 
 assert((a ^ b) == 175);
-screm(a ^ b);
+screm(a ^ b); // output 175
 
 assert((a << b) == 0);
-screm(a << b);
+screm(a << b); // output 0
 
 assert((a >> b) == 0);
-screm(a >> b);
+screm(a >> b); // output 0
 
 assert((~a) == -102);
-screm(~a);
+screm(~a); // output -102

--- a/examples/class.birb
+++ b/examples/class.birb
@@ -20,4 +20,4 @@ class test = Test;
 test.Test("Birb", 10);
 
 assert(test.getName() == "Birb" && test.getAge() == 10);
-screm(test.getName() + " : " + test.getAge());
+screm(test.getName() + " : " + test.getAge()); // output Birb : 10

--- a/examples/const.birb
+++ b/examples/const.birb
@@ -1,4 +1,4 @@
 const String henlo = "Henlo Birbo";
 
 assert(henlo == "Henlo Birbo");
-screm(henlo);
+screm(henlo); // output Henlo Birbo

--- a/examples/control_flow.birb
+++ b/examples/control_flow.birb
@@ -1,10 +1,14 @@
 int year = Date.year;
 
 if (year == 2020) {
-    screm("2020");
+    screm("2020"); // output 2020
 }
 
-for (int i = 0; i < 9; i += 1) {
+// output 0
+// output 1
+// output 2
+// output 3
+for (int i = 0; i < 4; i += 1) {
     screm(i);
 }
 
@@ -13,4 +17,4 @@ year += 1;
 }
 
 assert(year == 2030);
-screm(year);
+screm(year); // output 2030

--- a/examples/dart.birb
+++ b/examples/dart.birb
@@ -9,5 +9,5 @@
 }
 
 assert(foo.strMethod() == "bar");
-screm(foo.strMethod());
-
+screm(foo.strMethod()); // output bar
+// output foo

--- a/examples/decode_json.birb
+++ b/examples/decode_json.birb
@@ -6,4 +6,4 @@ String json = '
 Map map = decodeJson(json);
 
 assert(map["content"] == "foo");
-screm(map["content"]);
+screm(map["content"]); // output foo

--- a/examples/double.birb
+++ b/examples/double.birb
@@ -2,34 +2,34 @@ double price = 11.101010;
 
 
 //PROPERTIES
-screm(price.isFinite);
-screm(price.isInfinite);
-screm(price.isNaN);
-screm(price.isNegative);
-screm(price.sign);
-screm(price.runtimeType);
+screm(price.isFinite); // output true
+screm(price.isInfinite); // output false
+screm(price.isNaN); // output false
+screm(price.isNegative); // output false
+screm(price.sign); // output 1.0
+screm(price.runtimeType); // output double
 
 //METHODS
-screm(price.abs());
-screm(price.ceil());
-screm(price.ceilToDouble());
-screm(price.clamp(1.0, 10.0));
-screm(price.compareTo(5.0));
-screm(price.floor());
-screm(price.floorToDouble());
-screm(price.remainder(5.0));
-screm(price.round());
-screm(price.roundToDouble());
-screm(price.toInt());
-screm(price.toString());
-screm(price.toStringAsExponential());
-screm(price.toStringAsFixed(1));
-screm(price.toStringAsPrecision(1));
-screm(price.truncate());
-screm(price.truncateToDouble());
+screm(price.abs()); // output 11.10101
+screm(price.ceil()); // output 12
+screm(price.ceilToDouble()); // output 12.0
+screm(price.clamp(1.0, 10.0)); // output 10.0
+screm(price.compareTo(5.0)); // output 1
+screm(price.floor()); // output 11
+screm(price.floorToDouble()); // output 11.0
+screm(price.remainder(5.0)); // output 1.1010100000000005
+screm(price.round()); // output 11
+screm(price.roundToDouble()); // output 11.0
+screm(price.toInt()); // output 11
+screm(price.toString()); // output 11.10101
+screm(price.toStringAsExponential()); // output 1e+1
+screm(price.toStringAsFixed(1)); // output 11.1
+screm(price.toStringAsPrecision(1)); // output 1e+1
+screm(price.truncate()); // output 11
+screm(price.truncateToDouble()); // output 11.0
 
-screm(Double.infinity);
-screm(Double.negInfinity);
-screm(Double.nan);
-screm(Double.maxFinite);
-screm(Double.minPositive);
+screm(Double.infinity); // output Infinity
+screm(Double.negInfinity); // output -Infinity
+screm(Double.nan); // output NaN
+screm(Double.maxFinite); // output 1.7976931348623157e+308
+screm(Double.minPositive); // output 5e-324

--- a/examples/encode_json.birb
+++ b/examples/encode_json.birb
@@ -4,4 +4,4 @@ Map map = {
 
 String str = encodeJson(map);
 
-screm(str);
+screm(str); // output {"content":"foo"}

--- a/examples/final.birb
+++ b/examples/final.birb
@@ -1,2 +1,2 @@
 final String henlo = "Henlo Birbo";
-screm(henlo);
+screm(henlo); // output Henlo Birbo

--- a/examples/for_loop.birb
+++ b/examples/for_loop.birb
@@ -1,3 +1,13 @@
 for (int i = 0; i < 10; i++) {
     screm(i);
 }
+// output 0
+// output 1
+// output 2
+// output 3
+// output 4
+// output 5
+// output 6
+// output 7
+// output 8
+// output 9

--- a/examples/functions.birb
+++ b/examples/functions.birb
@@ -2,4 +2,4 @@ int add(int a, int b) {
     return a + b;
 }
 
-screm(add(0xA, 6));
+screm(add(0xA, 6)); // output 16

--- a/examples/grab.birb
+++ b/examples/grab.birb
@@ -1,4 +1,4 @@
-grab("./examples/class.birb");
+grab("./examples/class.birb"); // output Birb : 10
 Test.Test("foo", 20);
-screm(Test.getName());
-screm(Test.getAge());
+screm(Test.getName()); // output foo
+screm(Test.getAge()); // output 20

--- a/examples/henlo_birb.birb
+++ b/examples/henlo_birb.birb
@@ -1,1 +1,1 @@
-screm("Henlo Birb!");
+screm("Henlo Birb!"); // output Henlo Birb!

--- a/examples/int.birb
+++ b/examples/int.birb
@@ -1,19 +1,19 @@
 int i = 11;
 
-screm(i.bitLength);
-screm(i.isEven);
-screm(i.isFinite);
-screm(i.isInfinite);
-screm(i.isNaN);
-screm(i.isNegative);
-screm(i.isOdd);
-screm(i.sign);
-screm(i.runtimeType);
+screm(i.bitLength); // output 4
+screm(i.isEven); // output false
+screm(i.isFinite); // output true
+screm(i.isInfinite); // output false
+screm(i.isNaN); // output false
+screm(i.isNegative); // output false
+screm(i.isOdd); // output true
+screm(i.sign); // output 1
+screm(i.runtimeType); // output int
 
-screm(i.abs());
-screm(i.clamp(1, 10));
-screm(i.compareTo(6));
-screm(i.toStringAsExponential());
-screm(i.toUnsigned(1));
+screm(i.abs()); // output 11
+screm(i.clamp(1, 10)); // output 10
+screm(i.compareTo(6)); // output 1
+screm(i.toStringAsExponential()); // output 1e+1
+screm(i.toUnsigned(1)); // output 1
 
-screm(i + 0xFFAAA);
+screm(i + 0xFFAAA); // output 1047221

--- a/examples/list.birb
+++ b/examples/list.birb
@@ -1,3 +1,3 @@
 List list = [10];
 
-screm(list[0]);
+screm(list[0]); // output 10

--- a/examples/map.birb
+++ b/examples/map.birb
@@ -2,4 +2,4 @@ Map map = {
     "content": "This is a message"
 };
 
-screm(map["content"]);
+screm(map["content"]); // output This is a message

--- a/examples/string.birb
+++ b/examples/string.birb
@@ -7,13 +7,13 @@ henlo.trim(); // "Henlo Birb"
 henlo.toUpperCase(); // "HENLO BIRB"
 
 // "HENLO"
-screm(henlo.substring(0, 5));
+screm(henlo.substring(0, 5)); // output HENLO
 
 List colors = ['c', 'o', 'l', 'o', 'r', 's'];
-String colorStr = '';
+String colorStr = colors[0];
 
-for (int i = 0; i < colors.length; i++) {
-colorStr += '$' + (30 + i) + 'm' + colors[i];
+for (int i = 1; i < colors.length; i++) {
+colorStr += ' ' + colors[i];
 }
 
-screm(colorStr);
+screm(colorStr); // output c o l o r s

--- a/examples/switch.birb
+++ b/examples/switch.birb
@@ -1,7 +1,7 @@
 var foo = 15;
 switch (foo) {
     case 15: {
-        screm(15);
+        screm(15); // output 15
     }
     default: {
         screm("default");

--- a/examples/varAssign.birb
+++ b/examples/varAssign.birb
@@ -1,2 +1,4 @@
 var x = 1;
+screm(x); // output 1
 x = 2;
+screm(x); // output 2

--- a/examples/variables.birb
+++ b/examples/variables.birb
@@ -11,4 +11,4 @@ class Birb {
 }
 
 var i = 10;
-screm(i);
+screm(i); // output 10

--- a/examples/while_loop.birb
+++ b/examples/while_loop.birb
@@ -4,3 +4,13 @@ while (i < 10) {
     screm(i);
     i++;
 }
+// output 0
+// output 1
+// output 2
+// output 3
+// output 4
+// output 5
+// output 6
+// output 7
+// output 8
+// output 9

--- a/test/runtime_test.dart
+++ b/test/runtime_test.dart
@@ -3,6 +3,52 @@ import 'dart:io';
 import 'package:test/test.dart' as test;
 import 'package:test_process/test_process.dart';
 
+class ExpectationsParser {
+  final File file;
+
+  final _outputs = <String>[];
+  int _matchedOutputs = 0;
+
+  final _errors = <String>[];
+  int _matchedErrors = 0;
+
+  ExpectationsParser(this.file) {
+    _parseExpectations();
+  }
+
+  void _parseExpectations() {
+    final content = file.readAsStringSync();
+    final lines = content.split('\n');
+    lines.forEach((line) {
+      final commentStart = line.indexOf('//');
+      if (commentStart == -1) return;
+      // skip the two forward slashes
+      final comment = line.substring(commentStart+2).trimLeft();
+      if (comment.startsWith('output ')) {
+        _outputs.add(comment.substring('output '.length));
+      } else if (comment.startsWith('error ')) {
+        _errors.add(comment.substring('error '.length));
+      }
+    });
+  }
+
+  bool doesExpectOutput() => _outputs.isNotEmpty && _matchedOutputs != _outputs.length;
+
+  String nextOutput() {
+    assert(_matchedOutputs < _outputs.length);
+    return _outputs[_matchedOutputs++];
+  }
+
+  bool doesExpectError() => _errors.isNotEmpty && _matchedErrors != _errors.length;
+
+  String nextError() {
+    assert(_matchedErrors < _errors.length);
+    return _errors[_matchedErrors++];
+  }
+
+  String getError() => _matchedErrors == _errors.length ? null : _errors[_matchedErrors];
+}
+
 void main() {
   test.test('Runs program correctly', () async {
     var process = await TestProcess.start(
@@ -21,55 +67,53 @@ void main() {
     test.expect(line, test.equals('There is only 1 item in my good list'));
   });
 
-  test.group('All testFile programs run without errors', () {
+  test.group('All testFile programs run with expected results', () {
     Directory directory = Directory('./test/testFiles');
     directory.listSync().forEach((file) {
       test.test('${file.path}', () async {
-        var process =
-        await TestProcess.start('dart', ['./lib/birb.dart', file.path]);
-
-        while (await process.stderr.hasNext) {
-          var line = await process.stderr.next;
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('exception')));
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('error')));
-        }
-        while (await process.stdout.hasNext) {
-          var line = await process.stdout.next;
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('exception')));
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('error')));
-        }
-        await process.shouldExit();
+        await _testBirbScriptWithExpectations(file);
       });
     });
   });
 
-  test.group('All example programs run without errors', () {
+  test.group('All example programs run with expected results', () {
     Directory directory = Directory('./examples/');
     directory.listSync().forEach((file) {
       test.test('${file.path}', () async {
-        var process =
-            await TestProcess.start('dart', ['./lib/birb.dart', file.path]);
-
-        while (await process.stderr.hasNext) {
-          var line = await process.stderr.next;
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('exception')));
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('error')));
-        }
-        while (await process.stdout.hasNext) {
-          var line = await process.stdout.next;
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('exception')));
-          test.expect(
-              line.toLowerCase(), test.isNot(test.contains('error')));
-        }
-        await process.shouldExit();
+        await _testBirbScriptWithExpectations(file);
       });
     });
   });
+}
+
+Future _testBirbScriptWithExpectations(FileSystemEntity file) async {
+  final expectations = ExpectationsParser(file);
+  var process =
+  await TestProcess.start('dart', ['./lib/birb.dart', file.path]);
+  
+  // skip dart Warning for interpreting ./lib/birb.dart as package URI
+  final shouldFailOnError = !expectations.doesExpectError();
+  await for (final line in process.stderrStream().skip(1)) {
+    if (shouldFailOnError) {
+      test.fail('Unexpected error');
+    }
+    if (expectations.doesExpectError() && line.contains(expectations.getError())) {
+      expectations.nextError();
+    }
+  }
+  if (expectations.doesExpectError()) {
+    test.fail('expected ${expectations.nextError()} error next');
+  }
+
+  await for (final line in process.stdoutStream()) {
+    if (expectations.doesExpectOutput()) {
+      test.expect(line, test.equals(expectations.nextOutput()));
+    } else {
+      test.fail('Too many outputs: unexpected $line');
+    }
+  }
+  if (expectations.doesExpectOutput()) {
+    test.fail('Too few outputs: expected ${expectations.nextOutput()} next');
+  }
+  await process.shouldExit();
 }

--- a/test/testFiles/error_smoke.birb
+++ b/test/testFiles/error_smoke.birb
@@ -1,0 +1,1 @@
+this should error // error UndefinedVariableException

--- a/test/testFiles/output_smoke.birb
+++ b/test/testFiles/output_smoke.birb
@@ -1,0 +1,1 @@
+screm('Hello') // output Hello


### PR DESCRIPTION
This adds the ability to test for expected outputs and errors from Birb programs. To test for expected outputs add a comment with the following structure (don't include braces)
```
// output {output string here}
```
and for expected erros add a comment with the following structure (don't include braces)
```
// error {part of the error message or type}
```

closes #24 