### PR TITLE
Added Instructions for npm too as yarn is not widely used

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,32 +2,38 @@
 
 The BirbDocs website is built using [Docusaurus 2](https://v2.docusaurus.io/), a modern static website generator.
 
+The build and installation instructions can be followed using both npm or yarn. Any of those should work.
+
 ### Installation
 
-```
+```shell
+# Yarn
 $ yarn
+
+# npm
+$ npm install
 ```
 
 ### Local Development
 
-```
+```shell
+# Yarn
 $ yarn start
+
+# npm
+$ npm run start
 ```
 
 This command starts a local development server and open up a browser window. Most changes are reflected live without having to restart the server.
 
 ### Build
 
-```
+```shell
+# Yarn
 $ yarn build
+
+# npm
+$ npm run build
 ```
 
 This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-### Deployment
-
-```
-$ GIT_USER=<Your GitHub username> USE_SSH=true yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.


### PR DESCRIPTION
Added Instructions for npm too as yarn is not widely used. Also we do not need to show the github deploy thing.

CC @Calamity210 